### PR TITLE
feat: implement add category and get all categories functions

### DIFF
--- a/contracts/src/interface.cairo
+++ b/contracts/src/interface.cairo
@@ -6,7 +6,7 @@ pub struct Market {
     pub creator: ContractAddress,
     pub title: ByteArray,
     pub description: ByteArray,
-    pub category: ByteArray,
+    pub category: felt252,
     pub start_time: u64,
     pub end_time: u64,
     pub resolution_time: u64,
@@ -76,7 +76,7 @@ pub trait IPredictionMarket<TContractState> {
         ref self: TContractState,
         title: ByteArray,
         description: ByteArray,
-        category: ByteArray,
+        category: felt252,
         start_time: u64,
         end_time: u64,
         outcomes: Array<felt252>,
@@ -90,6 +90,9 @@ pub trait IPredictionMarket<TContractState> {
     #[external(v0)]
     fn claim_winnings(ref self: TContractState, market_id: u32);
 
+    #[external(v0)]
+    fn add_category(ref self: TContractState, category: felt252);
+
     // Getters
     #[external(v0)]
     fn get_market_details(self: @TContractState, market_id: u32) -> MarketDetails;
@@ -99,6 +102,9 @@ pub trait IPredictionMarket<TContractState> {
 
     #[external(v0)]
     fn get_market_stats(self: @TContractState, market_id: u32) -> (u256, Array<u256>);
+
+    #[external(v0)]
+    fn get_all_categories(self: @TContractState) -> Array<felt252>;
 
     // Administration
     fn assign_validator(ref self: TContractState, market_id: u32);

--- a/contracts/src/prediction.cairo
+++ b/contracts/src/prediction.cairo
@@ -126,6 +126,7 @@ pub mod PredictionMarket {
         category_array: Map<u32, felt252>, // Store categories by index
         category_to_id: Map<felt252, u32>, // Map category name to its ID
         category_count: u32,
+        admin: ContractAddress,
     }
 
     // Events
@@ -199,6 +200,9 @@ pub mod PredictionMarket {
         self.platform_fee.write(platform_fee);
         self.market_validator.write(market_validator_address);
         self.validator_index.write(0);
+
+        let deployer = get_caller_address();
+        self.admin.write(deployer);
     }
 
     // External Implementation
@@ -242,8 +246,7 @@ pub mod PredictionMarket {
         }
         
         fn add_category(ref self: ContractState, category: felt252) {
-            // assert(get_caller_address() == self.admin.read(), "Only admin can add categories");
-            // self.accesscontrol.assert_only_role(ADMIN_ROLE);
+            assert!(get_caller_address() == self.admin.read(), "Only admin can add categories");
             self._add_category(category);
         }
 

--- a/contracts/src/prediction.cairo
+++ b/contracts/src/prediction.cairo
@@ -352,6 +352,19 @@ pub mod PredictionMarket {
                     },
                 );
         }
+        
+        fn get_all_categories(self: @ContractState) -> Array<felt252> {
+            let count = self.category_count.read();
+            let mut categories = ArrayTrait::new();
+            
+            let mut i: u32 = 1;
+            while i <= count {
+                categories.append(self.category_array.entry(i).read());
+                i += 1;
+            }
+            
+            categories
+        }
 
         fn claim_winnings(ref self: ContractState, market_id: u32) {
             let caller = get_caller_address();
@@ -489,28 +502,28 @@ pub mod PredictionMarket {
             self.validator_index.write(current_index + 1);
             validator_contract.get_validator_by_index(index)
         }
-    }
 
-    fn _add_category(ref self: ContractState, category: felt252) -> u32 {
-        let category_exists = self.category_to_id.entry(category).read();
-
-        if category_exists != 0 {
-            return category_exists;
-        } else {
-            let new_id = self.category_count.read() + 1;
-            self.category_array.entry(new_id).write(category);
-            self.category_to_id.entry(category).write(new_id);
-            self.category_count.write(new_id);
-
-            self
-                .emit(
-                    CategoryCreated {
-                        category_id: new_id,
-                        name: category
-                    },
-                );
-            
-            return new_id;
+        fn _add_category(ref self: ContractState, category: felt252) -> u32 {
+            let category_exists = self.category_to_id.entry(category).read();
+    
+            if category_exists != 0 {
+                return category_exists;
+            } else {
+                let new_id = self.category_count.read() + 1;
+                self.category_array.entry(new_id).write(category);
+                self.category_to_id.entry(category).write(new_id);
+                self.category_count.write(new_id);
+    
+                self
+                    .emit(
+                        CategoryCreated {
+                            category_id: new_id,
+                            name: category
+                        },
+                    );
+                
+                return new_id;
+            }
         }
     }
 }

--- a/contracts/tests/test_prediction.cairo
+++ b/contracts/tests/test_prediction.cairo
@@ -459,3 +459,71 @@ fn test_set_prediction_should_panic_when_called_by_non_owner() {
     mv_contract.set_prediction_market(mock_prediction_market);
     stop_cheat_caller_address(mv_contract.contract_address);
 }
+
+// Test: Category Functionality
+#[test]
+fn test_category_functionality() {
+    // Deploy dependencies
+    let erc20 = deploy_mock_erc20();
+    let fee_collector = test_address();
+    let owner = test_address();
+    let mv_contract = deploy_market_validator(
+        test_address(), // PredictionMarket address (mock for now)
+        100_u256, 86400, 10, owner,
+    );
+    let pm_contract = deploy_prediction_market(
+        erc20.contract_address, fee_collector, 500_u256, // 5% fee
+        mv_contract.contract_address,
+    );
+
+    // Set caller as admin
+    start_cheat_caller_address(pm_contract.contract_address, owner);
+    set_block_timestamp(1000);
+
+    // Ensure initial state
+    let initial_categories = pm_contract.get_all_categories();
+    assert_eq!(initial_categories.len(), 0, "Should start with no categories");
+
+    // Add a category
+    let category1 = 91742371214451; // Sports
+    pm_contract.add_category(category1);
+    let categories_after_add = pm_contract.get_all_categories();
+    assert_eq!(categories_after_add.len(), 1);
+    assert_eq!(*categories_after_add[0], category1);
+
+    // Attempt duplicate category
+    pm_contract.add_category(category1);
+    let categories_after_duplicate = pm_contract.get_all_categories();
+    assert_eq!(categories_after_duplicate.len(), 1, "Duplicate should not be added");
+
+    // Add another category
+    let category2 = 5795970445629547379; // Politics
+    pm_contract.add_category(category2);
+    let categories_after_second = pm_contract.get_all_categories();
+    assert_eq!(categories_after_second.len(), 2);
+
+    // Add category via market creation
+    let title = "Finance Market";
+    let description = "Market about finance";
+    let category3 = 19819171171689317; // Finance
+    let outcomes = array![19819171171689317, 5795970445629547379]; // array!["Yes", "No"];
+    let start_time = 2000;
+    let end_time = 3000;
+    let min_stake = 10_u256;
+    let max_stake = 1000_u256;
+
+    pm_contract.create_market(
+        title, description, category3,
+        start_time, end_time, outcomes, min_stake, max_stake
+    );
+    let categories_after_market = pm_contract.get_all_categories();
+    assert_eq!(categories_after_market.len(), 3);
+    let mut category_found = false;
+    for category in categories_after_market {
+        if category == category3 {
+            category_found = true;
+            break;
+        }
+    }
+    assert!(category_found, "Category should exist in the list");
+}

--- a/contracts/tests/test_prediction.cairo
+++ b/contracts/tests/test_prediction.cairo
@@ -464,17 +464,15 @@ fn test_set_prediction_should_panic_when_called_by_non_owner() {
 #[test]
 fn test_category_functionality() {
     // Deploy dependencies
-    let erc20 = deploy_mock_erc20();
+    // let _erc20 = deploy_mock_erc20();
     let fee_collector = test_address();
     let owner = test_address();
     let mv_contract = deploy_market_validator(
         test_address(), // PredictionMarket address (mock for now)
         100_u256, 86400, 10, owner,
     );
-    let pm_contract = deploy_prediction_market(
-        erc20.contract_address, fee_collector, 500_u256, // 5% fee
-        mv_contract.contract_address,
-    );
+
+    let pm_contract = deploy_prediction_market(fee_collector, 500_u256, mv_contract.contract_address);
 
     // Set caller as admin
     start_cheat_caller_address(pm_contract.contract_address, owner);


### PR DESCRIPTION
## Detailed Information

This PR improves category listing function by introducing `get_all_categories()` functions which returns a list of all the categories which where added either via a dedicated `add_category()` function or when via `create_market()` function (category will be automatically added if it does not exist).
---

## Related Issues

Closes #89 

---

## Type of Change

- [x] 🐛 Bug fix or ⚙️ enhancement
- [x] ✨ New feature or Chore (change with no new features or fixes)
- [ ] 📚 Documentation update

---

## Checklist (select as many as applicable)

- [x] The code follows the style guidelines of this project.
- [ ] All new and existing tests pass.
- [x] This pull request is ready to be merged and reviewed.
