### PR TITLE
feat: add business prediction market functionality and corresponding …

### DIFF
--- a/contracts/src/interface.cairo
+++ b/contracts/src/interface.cairo
@@ -59,6 +59,25 @@ pub struct SportsPrediction {
     pub team_flag: bool // Flag indicating if this is a team-based prediction
 }
 
+/// Represents a business prediction market with binary (yes/no) outcomes
+/// Used for predictions about business (e.g., "Will over 50% of Fortune 500 companies adopt
+/// blockchain solutions by 2026?")
+#[derive(Drop, Serde, starknet::Store)]
+pub struct BusinessPrediction {
+    pub title: ByteArray, // Market title/question
+    pub market_id: u256, // Unique identifier for the market
+    pub description: ByteArray, // Detailed description of the prediction
+    pub choices: (Choice, Choice), // Binary choices (typically Yes/No)
+    pub category: felt252, // Category identifier for market classification
+    pub image_url: ByteArray, // URL to market image/icon
+    pub is_resolved: bool, // Whether the market has been resolved
+    pub is_open: bool, // Whether the market is accepting new bets
+    pub end_time: u64, // Timestamp when the market closes
+    pub winning_choice: Option<Choice>, // The winning choice after resolution
+    pub total_pool: u256, // Total amount staked in the market
+    pub event_id: u64 // External API event ID for automatic resolution
+}
+
 // ================ Supporting Types ================
 
 /// Represents a choice in a prediction market with its associated stake
@@ -130,6 +149,18 @@ pub trait IPredictionHub<TContractState> {
         team_flag: bool,
     );
 
+    /// Creates a new general prediction market with binary (yes/no) choices
+    fn create_business_prediction(
+        ref self: TContractState,
+        title: ByteArray,
+        description: ByteArray,
+        choices: (felt252, felt252),
+        category: felt252,
+        image_url: ByteArray,
+        end_time: u64,
+        event_id: u64,
+    );
+
     // ================ Market Queries ================
 
     /// Returns the total number of prediction markets created
@@ -152,6 +183,12 @@ pub trait IPredictionHub<TContractState> {
 
     /// Returns an array of all active sports prediction markets
     fn get_all_sports_predictions(self: @TContractState) -> Array<SportsPrediction>;
+
+    /// Retrieves a specific business prediction market by ID
+    fn get_business_prediction(self: @TContractState, market_id: u256) -> BusinessPrediction;
+
+    /// Returns an array of all active business prediction markets
+    fn get_all_business_predictions(self: @TContractState) -> Array<BusinessPrediction>;
 
     // ================ Betting Functions ================
 

--- a/contracts/src/interface.cairo
+++ b/contracts/src/interface.cairo
@@ -149,7 +149,7 @@ pub trait IPredictionHub<TContractState> {
         team_flag: bool,
     );
 
-    /// Creates a new general prediction market with binary (yes/no) choices
+    /// Creates a new business prediction market with binary (yes/no) choices
     fn create_business_prediction(
         ref self: TContractState,
         title: ByteArray,

--- a/contracts/src/prediction.cairo
+++ b/contracts/src/prediction.cairo
@@ -4,8 +4,8 @@ use pragma_lib::abi::{IPragmaABIDispatcher, IPragmaABIDispatcherTrait};
 use pragma_lib::types::DataType;
 use stakcast::admin_interface::IAdditionalAdmin;
 use stakcast::interface::{
-    Choice, CryptoPrediction, IPredictionHub, PredictionMarket, SportsPrediction, UserBet,
-    UserStake,
+    BusinessPrediction, Choice, CryptoPrediction, IPredictionHub, PredictionMarket,
+    SportsPrediction, UserBet, UserStake,
 };
 use starknet::storage::{Map, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess};
 use starknet::{ClassHash, ContractAddress, get_block_timestamp, get_caller_address};
@@ -95,6 +95,7 @@ pub mod PredictionHub {
         predictions: Map<u256, PredictionMarket>,
         crypto_predictions: Map<u256, CryptoPrediction>,
         sports_predictions: Map<u256, SportsPrediction>,
+        business_predictions: Map<u256, BusinessPrediction>,
         // User bets mapping: (user, market_id, market_type, bet_index) -> UserBet
         user_bets: Map<(ContractAddress, u256, u8, u8), UserBet>,
         user_bet_counts: Map<(ContractAddress, u256, u8), u8>,
@@ -257,6 +258,9 @@ pub mod PredictionHub {
                 assert(market.market_id == market_id, 'Market does not exist');
             } else if market_type == 2 {
                 let market = self.sports_predictions.entry(market_id).read();
+                assert(market.market_id == market_id, 'Market does not exist');
+            } else if market_type == 3 {
+                let market = self.business_predictions.entry(market_id).read();
                 assert(market.market_id == market_id, 'Market does not exist');
             } else {
                 panic!("Invalid market type");
@@ -445,6 +449,51 @@ pub mod PredictionHub {
             self.end_reentrancy_guard();
         }
 
+        fn create_business_prediction(
+            ref self: ContractState,
+            title: ByteArray,
+            description: ByteArray,
+            choices: (felt252, felt252),
+            category: felt252,
+            image_url: ByteArray,
+            end_time: u64,
+            event_id: u64,
+        ) {
+            self.assert_not_paused();
+            self.assert_market_creation_not_paused();
+            self.assert_only_moderator_or_admin();
+            self.assert_valid_market_timing(end_time);
+            self.start_reentrancy_guard();
+
+            let market_id = self.prediction_count.read() + 1;
+            self.prediction_count.write(market_id);
+
+            let (choice_0_label, choice_1_label) = choices;
+            let choice_0 = Choice { label: choice_0_label, staked_amount: 0 };
+            let choice_1 = Choice { label: choice_1_label, staked_amount: 0 };
+
+            let market = BusinessPrediction {
+                title,
+                market_id,
+                description,
+                choices: (choice_0, choice_1),
+                category,
+                image_url,
+                is_resolved: false,
+                is_open: true,
+                end_time,
+                winning_choice: Option::None,
+                total_pool: 0,
+                event_id,
+            };
+
+            self.business_predictions.entry(market_id).write(market);
+
+            self.emit(MarketCreated { market_id, creator: get_caller_address(), market_type: 3 });
+
+            self.end_reentrancy_guard();
+        }
+
         // ================ Market Queries ================
 
         fn get_prediction_count(self: @ContractState) -> u256 {
@@ -505,6 +554,27 @@ pub mod PredictionHub {
 
             while i <= count {
                 let market = self.sports_predictions.entry(i).read();
+                if market.market_id != 0 { // Check if market exists
+                    predictions.append(market);
+                }
+                i += 1;
+            }
+
+            predictions
+        }
+
+        fn get_business_prediction(self: @ContractState, market_id: u256) -> BusinessPrediction {
+            self.assert_market_exists(market_id, 3);
+            self.business_predictions.entry(market_id).read()
+        }
+
+        fn get_all_business_predictions(self: @ContractState) -> Array<BusinessPrediction> {
+            let mut predictions = ArrayTrait::new();
+            let count = self.prediction_count.read();
+            let mut i = 1;
+
+            while i <= count {
+                let market = self.business_predictions.entry(i).read();
                 if market.market_id != 0 { // Check if market exists
                     predictions.append(market);
                 }

--- a/contracts/tests/market_creation_tests.cairo
+++ b/contracts/tests/market_creation_tests.cairo
@@ -401,6 +401,50 @@ fn test_create_sports_prediction_non_team_event() {
     assert(choice_1.label == 'No', 'Choice 1 No');
 }
 
+// ================ Business Prediction Market Tests ================
+
+#[test]
+fn test_create_business_prediction_success() {
+    let (contract, _admin_contract) = setup_with_moderator();
+
+    start_cheat_caller_address(contract.contract_address, MODERATOR_ADDR());
+    let future_time = get_block_timestamp() + 86400; // 1 day from now
+
+    contract
+        .create_business_prediction(
+            "Will Microsoft acquire a gaming company by June 2025?",
+            "business Predictions for Microsoft to acquire a specific gaming company by June 2025?",
+            ('Yes', 'No'),
+            'business_acquisition',
+            "https://example.com/microsoft-image.png",
+            future_time,
+            45637 // Event ID
+        );
+
+    // Verify market count increased
+    let count = contract.get_prediction_count();
+    println!("Market count: {}", count);
+    assert(count == 1, 'Market count should be 1');
+
+    // Verify market data
+    let market = contract.get_business_prediction(1);
+    assert(market.market_id == 1, 'Market ID should be 1');
+    assert(
+        market.title == "Will Microsoft acquire a gaming company by June 2025?", 'Title mismatch',
+    );
+    assert(market.is_open, 'Market should be open');
+    assert(!market.is_resolved, 'Market not resolved');
+    assert(market.total_pool == 0, 'Initial pool 0');
+    assert(market.end_time == future_time, 'End time mismatch');
+
+    // Verify choices
+    let (choice_0, choice_1) = market.choices;
+    assert(choice_0.label == 'Yes', 'Choice 0 label mismatch');
+    assert(choice_1.label == 'No', 'Choice 1 label mismatch');
+
+    let business_market = contract.get_all_business_predictions();
+    assert(business_market.len() == 1, 'Should return 1 business market');
+}
 // ================ Mixed Market Type Tests ================
 
 #[test]
@@ -447,28 +491,43 @@ fn test_create_all_market_types() {
             555,
             true,
         );
+    // Create business prediction
+    contract
+        .create_business_prediction(
+            "Will Microsoft acquire a gaming company by June 2025?",
+            "business Predictions for Microsoft to acquire a specific gaming company by June 2025?",
+            ('Yes', 'No'),
+            'business_acquisition',
+            "https://example.com/microsoft-image.png",
+            future_time,
+            45637 // Event ID
+        );
 
     // Verify total count
     let count = contract.get_prediction_count();
-    assert(count == 3, 'Should have 3 markets');
+    assert(count == 4, 'Should have 4 markets');
 
     // Verify each market type exists
     let general_market = contract.get_prediction(1);
     let crypto_market = contract.get_crypto_prediction(2);
     let sports_market = contract.get_sports_prediction(3);
+    let business_market = contract.get_business_prediction(4);
 
     assert(general_market.market_id == 1, 'General market ID 1');
     assert(crypto_market.market_id == 2, 'Crypto market ID 2');
     assert(sports_market.market_id == 3, 'Sports market ID 3');
+    assert(business_market.market_id == 4, 'Business market ID 4');
 
     // Test get_all functions
     let all_general = contract.get_all_predictions();
     let all_crypto = contract.get_all_crypto_predictions();
     let all_sports = contract.get_all_sports_predictions();
+    let all_business = contract.get_all_business_predictions();
 
     assert(all_general.len() == 1, '1 general market');
     assert(all_crypto.len() == 1, '1 crypto market');
     assert(all_sports.len() == 1, '1 sports market');
+    assert(all_business.len() == 1, '1 business market');
 }
 
 // ================ Admin and Moderator Management Tests ================


### PR DESCRIPTION
…tests

## Detailed Information
this pr creates a new prediction market for business 
implement 
`  

    fn create_business_prediction(
        ref self: TContractState,
        title: ByteArray,
        description: ByteArray,
        choices: (felt252, felt252),
        category: felt252,
        image_url: ByteArray,
        end_time: u64,
        event_id: u64,
    );`
    
        /// Retrieves a specific business prediction market by ID
    fn get_business_prediction(self: @TContractState, market_id: u256) -> BusinessPrediction;

    /// Returns an array of all active business prediction markets
    fn get_all_business_predictions(self: @TContractState) -> Array<BusinessPrediction>;`
    
    with this stakcast contract has 4 diferent prediction market

---

## Related Issues

Closes #149 

---

## Type of Change

- [ ] 🐛 Bug fix or ⚙️ enhancement
- [x] ✨ New feature or Chore (change with no new features or fixes)
- [ ] 📚 Documentation update

---

## Checklist (select as many as applicable)

- [x] The code follows the style guidelines of this project.
- [x] All new and existing tests pass.
- [x] This pull request is ready to be merged and reviewed.
