### PR TITLE
Update ERC20 mock to strktoken

### DIFF
--- a/contracts/src/mocks/erc20.cairo
+++ b/contracts/src/mocks/erc20.cairo
@@ -1,36 +1,82 @@
+// SPDX-License-Identifier: MIT
+use starknet::ContractAddress;
+
+#[starknet::interface]
+trait IExternal<ContractState> {
+    fn mint(ref self: ContractState, recipient: ContractAddress, amount: u256);
+}
 #[starknet::contract]
-pub mod MockERC20 {
+pub mod strktoken {
+    use core::byte_array::ByteArray;
+    use openzeppelin::access::ownable::OwnableComponent;
+    use openzeppelin::token::erc20::interface::IERC20Metadata;
     use openzeppelin::token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
     use starknet::ContractAddress;
+    use starknet::storage::{StoragePointerReadAccess, StoragePointerWriteAccess};
 
     component!(path: ERC20Component, storage: erc20, event: ERC20Event);
-
-    #[abi(embed_v0)]
-    impl ERC20Impl = ERC20Component::ERC20Impl<ContractState>;
-    #[abi(embed_v0)]
-    impl ERC20MetadataImpl = ERC20Component::ERC20MetadataImpl<ContractState>;
-    impl ERC20InternalImpl = ERC20Component::InternalImpl<ContractState>;
+    component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
 
     #[storage]
-    struct Storage {
+    pub struct Storage {
         #[substorage(v0)]
-        erc20: ERC20Component::Storage,
+        pub erc20: ERC20Component::Storage,
+        #[substorage(v0)]
+        pub ownable: OwnableComponent::Storage,
+        custom_decimals: u8,
+        token_name: ByteArray,
+        token_symbol: ByteArray,
     }
 
     #[event]
     #[derive(Drop, starknet::Event)]
-    pub enum Event {
+    enum Event {
         #[flat]
         ERC20Event: ERC20Component::Event,
+        #[flat]
+        OwnableEvent: OwnableComponent::Event,
     }
 
     #[constructor]
-    fn constructor(ref self: ContractState, initial_owner: ContractAddress) {
-        let name = "Mock Token";
-        let symbol = "MOCK";
-        let total_supply = 10000000000000000000000000_u256;
-
+    fn constructor(
+        ref self: ContractState, recipient: ContractAddress, owner: ContractAddress, decimals: u8,
+    ) {
+        let name: ByteArray = "STRK";
+        let symbol: ByteArray = "STRK";
+        // Initialize the ERC20 component
         self.erc20.initializer(name, symbol);
-        self.erc20.mint(initial_owner, total_supply);
+        self.ownable.initializer(owner);
+        self.custom_decimals.write(decimals);
+        self.erc20.mint(recipient, 900_000_000_000_000_000_000_000_000_000_000);
+    }
+
+    #[abi(embed_v0)]
+    impl CustomERC20MetadataImpl of IERC20Metadata<ContractState> {
+        fn name(self: @ContractState) -> ByteArray {
+            self.token_name.read()
+        }
+
+        fn symbol(self: @ContractState) -> ByteArray {
+            self.token_symbol.read()
+        }
+
+        fn decimals(self: @ContractState) -> u8 {
+            self.custom_decimals.read() // Return custom value
+        }
+    }
+
+    // Keep existing implementations
+    #[abi(embed_v0)]
+    impl ERC20Impl = ERC20Component::ERC20Impl<ContractState>;
+    #[abi(embed_v0)]
+    impl OwnableImpl = OwnableComponent::OwnableImpl<ContractState>;
+    impl InternalImpl = ERC20Component::InternalImpl<ContractState>;
+    impl OwnableInternalImpl = OwnableComponent::InternalImpl<ContractState>;
+
+    #[abi(embed_v0)]
+    impl ExternalImpl of super::IExternal<ContractState> {
+        fn mint(ref self: ContractState, recipient: ContractAddress, amount: u256) {
+            self.erc20.mint(recipient, amount);
+        }
     }
 }

--- a/contracts/tests/bet_management_tests.cairo
+++ b/contracts/tests/bet_management_tests.cairo
@@ -43,8 +43,8 @@ fn PRAGMA_ORACLE_ADDR() -> ContractAddress {
 // ================ Test Setup ================
 
 fn deploy_test_token() -> IERC20Dispatcher {
-    let contract = declare("MockERC20").unwrap().contract_class();
-    let constructor_calldata = array![USER1_ADDR().into()];
+    let contract = declare("strktoken").unwrap().contract_class();
+    let constructor_calldata = array![USER1_ADDR().into(), ADMIN_ADDR().into(), 18];
 
     let (contract_address, _) = contract.deploy(@constructor_calldata).unwrap();
     IERC20Dispatcher { contract_address }
@@ -122,6 +122,8 @@ fn test_place_wager_success() {
 
     // Place wager
     start_cheat_caller_address(prediction_hub.contract_address, USER1_ADDR());
+    let user_balance_before = token.balance_of(USER1_ADDR());
+
     let result = prediction_hub.place_wager(market_id, 0, 1000000000000000000000, 0); // 1000 tokens
     stop_cheat_caller_address(prediction_hub.contract_address);
 
@@ -139,11 +141,9 @@ fn test_place_wager_success() {
 
     // Verify token balances changed
     let user_balance = token.balance_of(USER1_ADDR());
-
-    let expected_balance = 9500000000000000000000000 - 1000000000000000000000; // 9.5M - 1k
+    let expected_balance = user_balance_before - 1000000000000000000000; // 9.5M - 1k
     assert(user_balance == expected_balance, 'User balance incorrect');
 }
-
 #[test]
 fn test_place_wager_with_custom_fees() {
     let (prediction_hub, admin_interface, token) = setup_test_environment();
@@ -170,6 +170,45 @@ fn test_place_wager_with_custom_fees() {
     let fee_recipient_balance = token.balance_of(FEE_RECIPIENT_ADDR());
     assert(fee_recipient_balance == expected_fee, 'Fee recipient balance incorrect');
 }
+
+
+#[test]
+fn test_multiple_bets_same_user() {
+    let (prediction_hub, _admin_interface, token) = setup_test_environment();
+    let market_id = create_test_market(prediction_hub);
+
+    let mut spy = spy_events();
+
+    // Place wager
+    start_cheat_caller_address(prediction_hub.contract_address, USER1_ADDR());
+    let user_balance_before = token.balance_of(USER1_ADDR());
+    let result = prediction_hub.place_wager(market_id, 0, 1000000000000000000000, 0); // 1000 tokens
+    stop_cheat_caller_address(prediction_hub.contract_address);
+    assert(result, 'Wager placement failed');
+
+    // Check events were emitted
+    let events = spy.get_events();
+    assert(
+        events.events.len() >= 3, 'Expected multiple events',
+    ); // FeesCollected, WagerPlaced, BetPlaced
+
+    let expected_balance = 9500000000000000000000000 - 1000000000000000000000; // 9.5M - 1k
+    // Verify user bet was recorded
+    let bet_count = prediction_hub.get_bet_count_for_market(USER1_ADDR(), market_id, 0);
+    assert(bet_count == 1, 'Bet count incorrect');
+
+    // Verify token balances changed
+    let user_balance = token.balance_of(USER1_ADDR());
+    let expected_balance = user_balance_before - 1000000000000000000000; // 9.5M - 1k
+    assert(user_balance == expected_balance, 'User balance incorrect');
+
+    start_cheat_caller_address(prediction_hub.contract_address, USER1_ADDR());
+    let result2 = prediction_hub
+        .place_wager(market_id, 0, 1000000000000000000000, 0); // 1000 tokens
+    stop_cheat_caller_address(prediction_hub.contract_address);
+    assert(result2, 'Wager placement failed');
+}
+
 
 #[test]
 fn test_multiple_wagers_same_user() {

--- a/contracts/tests/integration_bet_system.cairo
+++ b/contracts/tests/integration_bet_system.cairo
@@ -57,8 +57,8 @@ fn test_complete_bet_management_workflow() {
     // ================ Setup Phase ================
 
     // Deploy mock ERC20 token
-    let token_contract = declare("MockERC20").unwrap().contract_class();
-    let token_calldata = array![USER1().into()];
+    let token_contract = declare("strktoken").unwrap().contract_class();
+    let token_calldata = array![USER1().into(), ADMIN_ADDR().into(), 18];
     let (token_address, _) = token_contract.deploy(@token_calldata).unwrap();
     let token = IERC20Dispatcher { contract_address: token_address };
 
@@ -299,13 +299,17 @@ fn test_complete_bet_management_workflow() {
     println!("Final TVL: {}", prediction_hub.get_total_value_locked());
 }
 
+fn ADMIN_ADDR() -> ContractAddress {
+    'ADMIN'.try_into().unwrap()
+}
+
 // ================ Edge Cases Test ================
 
 #[test]
 fn test_edge_cases_and_error_conditions() {
     // Setup similar to above but simplified
-    let token_contract = declare("MockERC20").unwrap().contract_class();
-    let token_calldata = array![USER1().into()];
+    let token_contract = declare("strktoken").unwrap().contract_class();
+    let token_calldata = array![USER1().into(), ADMIN_ADDR().into(), 18];
     let (token_address, _) = token_contract.deploy(@token_calldata).unwrap();
     let token = IERC20Dispatcher { contract_address: token_address };
 

--- a/contracts/tests/market_creation_tests.cairo
+++ b/contracts/tests/market_creation_tests.cairo
@@ -48,8 +48,8 @@ fn PRAGMA_ORACLE_ADDR() -> ContractAddress {
 
 fn deploy_contract() -> (IPredictionHubDispatcher, IAdditionalAdminDispatcher) {
     // Deploy mock ERC20 token
-    let token_contract = declare("MockERC20").unwrap().contract_class();
-    let token_calldata = array![USER1_ADDR().into()];
+    let token_contract = declare("strktoken").unwrap().contract_class();
+    let token_calldata = array![USER1_ADDR().into(), ADMIN_ADDR().into(), 18];
     let (token_address, _) = token_contract.deploy(@token_calldata).unwrap();
 
     let contract = declare("PredictionHub").unwrap().contract_class();

--- a/contracts/tests/multi_token_tests.cairo
+++ b/contracts/tests/multi_token_tests.cairo
@@ -50,8 +50,8 @@ fn PRAGMA_ORACLE_ADDR() -> ContractAddress {
 // ================ Mock Token Setup ================
 
 fn deploy_mock_token(recipient: ContractAddress, symbol: ByteArray) -> IERC20Dispatcher {
-    let contract = declare("MockERC20").unwrap().contract_class();
-    let constructor_calldata = array![recipient.into()];
+    let contract = declare("strktoken").unwrap().contract_class();
+    let constructor_calldata = array![recipient.into(), ADMIN_ADDR().into(), 18];
 
     let (contract_address, _) = contract.deploy(@constructor_calldata).unwrap();
     IERC20Dispatcher { contract_address }


### PR DESCRIPTION
Replace the mock ERC20 token implementation with a new token named strktoken, incorporating additional parameters for recipient and decimals during deployment.