### PR TITLE
Add support for market updates

### DIFF
--- a/contracts/src/events.cairo
+++ b/contracts/src/events.cairo
@@ -82,6 +82,19 @@ pub struct MarketForceClosed {
     pub time: u64,
 }
 
+#[derive(Drop, starknet::Event)]
+pub struct MarketExtended {
+    #[key]
+    pub market_id: u256,
+    pub new_end_time: u64,
+}
+
+#[derive(Drop, starknet::Event)]
+pub struct MarketModified {
+    #[key]
+    pub market_id: u256,
+}
+
 // ================ Main Event Enum ================
 
 #[derive(Drop, starknet::Event)]
@@ -97,4 +110,6 @@ pub enum Event {
     BetPlaced: BetPlaced,
     MarketEmergencyClosed: MarketEmergencyClosed,
     MarketForceClosed: MarketForceClosed,
+    MarketExtended: MarketExtended,
+    MarketModified: MarketModified,
 }

--- a/contracts/src/interface.cairo
+++ b/contracts/src/interface.cairo
@@ -23,6 +23,12 @@ pub trait IPredictionHub<TContractState> {
         crypto_prediction: Option<(felt252, u128)>,
     );
 
+    /// Extends the duration of an existing market
+    fn extend_market_duration(ref self: TContractState, market_id: u256, new_end_time: u64);
+
+    /// Modifies the description of an existing market
+    fn modify_market_details(ref self: TContractState, market_id: u256, new_description: ByteArray);
+
     // ================ Market Queries ================
 
     /// Returns the total number of prediction markets created


### PR DESCRIPTION
## Detailed Information

This PR introduces new functionality to allow moderators and admins to modify existing prediction markets after creation, providing greater flexibility in market management.

- **Market Duration Extension**: Moderators and admins can now extend the end time of active markets
- **Market Description Modification**: Ability to update market descriptions after creation

### Core Implementation

#### New Events
- `MarketExtended`: Emitted when a market's duration is extended
  - Contains `market_id` and `new_end_time`
- `MarketModified`: Emitted when market details are updated
  - Contains `market_id`

#### New Interface Methods
- `extend_market_duration(market_id: u256, new_end_time: u64)`
- `modify_market_details(market_id: u256, new_description: ByteArray)`

#### Security & Validation
Both functions include comprehensive validation:
- **Access Control**: Only moderators and admins can perform these operations
- **Market State Checks**: Operations are blocked on resolved markets
- **Time Validation**: New end times must be in the future and later than current end time
- **Duration Limits**: Extended markets still respect maximum duration constraints

### Testing
Added comprehensive test coverage including:
- ✅ Successful extension and modification scenarios
- ✅ Admin and moderator access verification
- ✅ Unauthorized access prevention
- ✅ Invalid input handling (non-existent markets, resolved markets, invalid times)
- ✅ Event emission verification

---

## Related Issues

Closes #254

---

## Type of Change

- [ ] 🐛 Bug fix or ⚙️ enhancement
- [x] ✨ New feature or Chore (change with no new features or fixes)
- [ ] 📚 Documentation update

---

## Checklist (select as many as applicable)

- [x] The code follows the style guidelines of this project.
- [x] All new and existing tests pass.
- [x] This pull request is ready to be merged and reviewed.
