### PR TITLE
feat: add force close and emergency resolve functionalities to admin interface

### DIFF
--- a/contracts/src/admin_interface.cairo
+++ b/contracts/src/admin_interface.cairo
@@ -90,10 +90,14 @@ pub trait IAdditionalAdmin<TContractState> {
     /// Emergency function to close a specific market (admin only)
     fn emergency_close_market(ref self: TContractState, market_id: u256);
 
+    /// Force close a market with a reason (admin only)
+    fn force_close_market(ref self: TContractState, market_id: u256, reason: ByteArray);
+
     /// Batch function to close multiple markets (admin only)
     fn emergency_close_multiple_markets(ref self: TContractState, market_ids: Array<u256>);
 
     /// Emergency function to resolve a specific market (admin only)
+    fn emergency_resolve_market(ref self: TContractState, market_id: u256, winning_choice: u8);
 
     /// Batch function to resolve multiple markets (admin only)
     fn emergency_resolve_multiple_markets(

--- a/contracts/src/events.cairo
+++ b/contracts/src/events.cairo
@@ -74,6 +74,14 @@ pub struct MarketEmergencyClosed {
     pub time: u64,
 }
 
+#[derive(Drop, starknet::Event)]
+pub struct MarketForceClosed {
+    pub market_id: u256,
+    pub reason: ByteArray,
+    pub closed_by: ContractAddress,
+    pub time: u64,
+}
+
 // ================ Main Event Enum ================
 
 #[derive(Drop, starknet::Event)]
@@ -88,4 +96,5 @@ pub enum Event {
     WinningsCollected: WinningsCollected,
     BetPlaced: BetPlaced,
     MarketEmergencyClosed: MarketEmergencyClosed,
+    MarketForceClosed: MarketForceClosed,
 }

--- a/contracts/src/prediction.cairo
+++ b/contracts/src/prediction.cairo
@@ -5,7 +5,7 @@ use pragma_lib::types::DataType;
 use stakcast::admin_interface::IAdditionalAdmin;
 use stakcast::events::{
     BetPlaced, EmergencyPaused, Event, FeesCollected, MarketCreated, MarketEmergencyClosed,
-    MarketResolved, ModeratorAdded, ModeratorRemoved, WagerPlaced, WinningsCollected,
+    MarketForceClosed, MarketResolved, ModeratorAdded, ModeratorRemoved, WagerPlaced, WinningsCollected,
 };
 use stakcast::interface::IPredictionHub;
 use stakcast::types::{BetActivity, Choice, MarketStatus, Outcome, PredictionMarket, UserStake};
@@ -1269,6 +1269,23 @@ pub mod PredictionHub {
             self.emit(MarketEmergencyClosed { market_id, time: current_time });
         }
 
+        fn force_close_market(ref self: ContractState, market_id: u256, reason: ByteArray) {
+            self.assert_only_admin();
+            self.assert_market_exists(market_id);
+            self.assert_market_not_resolved(market_id);
+
+            let mut prediction: PredictionMarket = self.all_predictions.entry(market_id).read();
+            let current_time = get_block_timestamp();
+            prediction.status = MarketStatus::Closed;
+            prediction.is_open = false;
+            self.all_predictions.entry(market_id).write(prediction);
+            self.emit(MarketForceClosed { 
+                market_id, 
+                reason, 
+                closed_by: get_caller_address(), 
+                time: current_time 
+            });
+        }
 
         fn emergency_close_multiple_markets(ref self: ContractState, market_ids: Array<u256>) {
             self.assert_only_admin();
@@ -1279,12 +1296,48 @@ pub mod PredictionHub {
         }
 
 
+        fn emergency_resolve_market(ref self: ContractState, market_id: u256, winning_choice: u8) {
+            self.assert_only_admin();
+            self.assert_market_exists(market_id);
+            self.assert_market_not_resolved(market_id);
+            self.assert_valid_choice(winning_choice);
+
+            self.start_reentrancy_guard();
+
+            let mut market = self.all_predictions.entry(market_id).read();
+            market.is_resolved = true;
+            market.is_open = false;
+            market.winning_choice = Option::Some(winning_choice);
+            
+            let winning_choice_outcome: Outcome = self.choice_num_to_outcome(market_id, winning_choice);
+            market.status = MarketStatus::Resolved(winning_choice_outcome);
+
+            self.all_predictions.entry(market_id).write(market);
+            self.emit(MarketResolved { 
+                market_id, 
+                resolver: get_caller_address(), 
+                winning_choice 
+            });
+
+            self.end_reentrancy_guard();
+        }
+
         fn emergency_resolve_multiple_markets(
             ref self: ContractState,
             market_ids: Array<u256>,
             market_types: Array<u8>,
             winning_choices: Array<u8>,
-        ) {}
+        ) {
+            self.assert_only_admin();
+            assert(market_ids.len() == winning_choices.len(), 'Arrays must have same length');
+            assert(market_ids.len() == market_types.len(), 'Arrays must have same length');
+            
+            for i in 0..market_ids.len() {
+                let market_id = *market_ids.at(i);
+                let winning_choice = *winning_choices.at(i);
+                self.emergency_resolve_market(market_id, winning_choice);
+            }
+        }
 
 
         fn set_protocol_token(ref self: ContractState, token_address: ContractAddress) {

--- a/contracts/tests/test_admin.cairo
+++ b/contracts/tests/test_admin.cairo
@@ -189,3 +189,178 @@ fn test_emergency_close_multiple_markets_succcess() {
     assert(market3.status == MarketStatus::Closed, 'Market 3 should be closed');
     assert(!market3.is_open, 'Market 3 should be closed');
 }
+
+#[test]
+fn test_force_close_market() {
+    let (contract, admin_interface, _token) = setup_test_environment();
+    start_cheat_caller_address(contract.contract_address, MODERATOR_ADDR());
+    let market_id_1 = create_test_market(contract);
+    stop_cheat_caller_address(contract.contract_address);
+
+    let user1 = USER1_ADDR();
+    // User 1 bets on market
+    start_cheat_caller_address(contract.contract_address, user1);
+    contract.buy_shares(market_id_1, 0, turn_number_to_precision_point(10));
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Force close the market with a reason
+    start_cheat_caller_address(admin_interface.contract_address, ADMIN_ADDR());
+    let reason = "Emergency situation";
+    admin_interface.force_close_market(market_id_1, reason);
+    stop_cheat_caller_address(admin_interface.contract_address);
+
+    let market = contract.get_prediction(market_id_1);
+    assert(market.status == MarketStatus::Closed, 'Market should be closed');
+    assert(!market.is_open, 'Market should be closed');
+}
+
+#[test]
+#[should_panic(expected: ('Only admin allowed',))]
+fn test_force_close_market_panics_if_not_admin() {
+    let (contract, admin_interface, _token) = setup_test_environment();
+
+    // Create a market as moderator
+    start_cheat_caller_address(contract.contract_address, MODERATOR_ADDR());
+    let market_id_1 = create_test_market(contract);
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Try to force close the market as a non-admin (user1)
+    let user1 = USER1_ADDR();
+    start_cheat_caller_address(admin_interface.contract_address, user1);
+    let reason = "Emergency situation";
+    admin_interface.force_close_market(market_id_1, reason);
+    stop_cheat_caller_address(admin_interface.contract_address);
+}
+
+#[test]
+#[should_panic(expected: ('Market does not exist',))]
+fn test_force_close_market_panics_if_non_existing_market() {
+    let (_, admin_interface, _token) = setup_test_environment();
+
+    let market_id_1 = 234;
+    let reason = "Emergency situation";
+
+    start_cheat_caller_address(admin_interface.contract_address, ADMIN_ADDR());
+    admin_interface.force_close_market(market_id_1, reason);
+    stop_cheat_caller_address(admin_interface.contract_address);
+}
+
+#[test]
+fn test_emergency_resolve_market() {
+    let (contract, admin_interface, _token) = setup_test_environment();
+    start_cheat_caller_address(contract.contract_address, MODERATOR_ADDR());
+    let market_id_1 = create_test_market(contract);
+    stop_cheat_caller_address(contract.contract_address);
+
+    let user1 = USER1_ADDR();
+    // User 1 bets on market
+    start_cheat_caller_address(contract.contract_address, user1);
+    contract.buy_shares(market_id_1, 0, turn_number_to_precision_point(10));
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Emergency resolve the market with winning choice 0
+    start_cheat_caller_address(admin_interface.contract_address, ADMIN_ADDR());
+    admin_interface.emergency_resolve_market(market_id_1, 0);
+    stop_cheat_caller_address(admin_interface.contract_address);
+
+    let market = contract.get_prediction(market_id_1);
+    assert(market.is_resolved, 'Market resolved');
+    assert(!market.is_open, 'Market closed');
+    assert(market.winning_choice.is_some(), 'Has winning choice');
+    assert(market.winning_choice.unwrap() == 0, 'Choice is 0');
+}
+
+#[test]
+#[should_panic(expected: ('Only admin allowed',))]
+fn test_emergency_resolve_market_panics_if_not_admin() {
+    let (contract, admin_interface, _token) = setup_test_environment();
+
+    // Create a market as moderator
+    start_cheat_caller_address(contract.contract_address, MODERATOR_ADDR());
+    let market_id_1 = create_test_market(contract);
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Try to emergency resolve the market as a non-admin (user1)
+    let user1 = USER1_ADDR();
+    start_cheat_caller_address(admin_interface.contract_address, user1);
+    admin_interface.emergency_resolve_market(market_id_1, 0);
+    stop_cheat_caller_address(admin_interface.contract_address);
+}
+
+#[test]
+#[should_panic(expected: ('Market does not exist',))]
+fn test_emergency_resolve_market_panics_if_non_existing_market() {
+    let (_, admin_interface, _token) = setup_test_environment();
+
+    let market_id_1 = 234;
+
+    start_cheat_caller_address(admin_interface.contract_address, ADMIN_ADDR());
+    admin_interface.emergency_resolve_market(market_id_1, 0);
+    stop_cheat_caller_address(admin_interface.contract_address);
+}
+
+#[test]
+#[should_panic(expected: ('Invalid choice selected',))]
+fn test_emergency_resolve_market_panics_if_invalid_choice() {
+    let (contract, admin_interface, _token) = setup_test_environment();
+
+    // Create a market as moderator
+    start_cheat_caller_address(contract.contract_address, MODERATOR_ADDR());
+    let market_id_1 = create_test_market(contract);
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Try to emergency resolve with invalid choice (2)
+    start_cheat_caller_address(admin_interface.contract_address, ADMIN_ADDR());
+    admin_interface.emergency_resolve_market(market_id_1, 2);
+    stop_cheat_caller_address(admin_interface.contract_address);
+}
+
+#[test]
+fn test_emergency_resolve_multiple_markets() {
+    let (contract, admin_interface, _token) = setup_test_environment();
+
+    start_cheat_caller_address(contract.contract_address, MODERATOR_ADDR());
+    let market_id_1 = create_test_market(contract);
+    let market_id_2 = create_test_market(contract);
+    let market_id_3 = create_test_market(contract);
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Emergency resolve all markets at once
+    start_cheat_caller_address(admin_interface.contract_address, ADMIN_ADDR());
+    let market_ids = array![market_id_1, market_id_2, market_id_3];
+    let market_types = array![0, 0, 0]; // Not used in current implementation
+    let winning_choices = array![0, 1, 0];
+    admin_interface.emergency_resolve_multiple_markets(market_ids, market_types, winning_choices);
+    stop_cheat_caller_address(admin_interface.contract_address);
+
+    // Assert all markets are resolved
+    let market1 = contract.get_prediction(market_id_1);
+    let market2 = contract.get_prediction(market_id_2);
+    let market3 = contract.get_prediction(market_id_3);
+
+    assert(market1.is_resolved, 'Market 1 resolved');
+    assert(market1.winning_choice.unwrap() == 0, 'Market 1 choice 0');
+    assert(market2.is_resolved, 'Market 2 resolved');
+    assert(market2.winning_choice.unwrap() == 1, 'Market 2 choice 1');
+    assert(market3.is_resolved, 'Market 3 resolved');
+    assert(market3.winning_choice.unwrap() == 0, 'Market 3 choice 0');
+}
+
+#[test]
+#[should_panic(expected: ('Arrays must have same length',))]
+fn test_emergency_resolve_multiple_markets_panics_if_arrays_mismatch() {
+    let (contract, admin_interface, _token) = setup_test_environment();
+
+    start_cheat_caller_address(contract.contract_address, MODERATOR_ADDR());
+    let market_id_1 = create_test_market(contract);
+    let market_id_2 = create_test_market(contract);
+    stop_cheat_caller_address(contract.contract_address);
+
+    // Try to resolve with mismatched array lengths
+    start_cheat_caller_address(admin_interface.contract_address, ADMIN_ADDR());
+    let market_ids = array![market_id_1, market_id_2];
+    let market_types = array![0, 0, 0]; // Extra element
+    let winning_choices = array![0, 1];
+    admin_interface.emergency_resolve_multiple_markets(market_ids, market_types, winning_choices);
+    stop_cheat_caller_address(admin_interface.contract_address);
+}


### PR DESCRIPTION

## Detailed Information
 **add force close and emergency resolve functionalities to admin interface**

- Introduced `force_close_market` method to allow admins to close markets with a specified reason.
- Added `emergency_resolve_market` method for resolving markets by admin with a winning choice.
- Updated event structures to include `MarketForceClosed` for tracking forced closures.
- Enhanced tests to cover new functionalities and ensure proper admin restrictions.

Closes #253 

## Type of Change

- [x] 🐛 Bug fix or ⚙️ enhancement
- [x] ✨ New feature or Chore (change with no new features or fixes)
- [ ] 📚 Documentation update

## Checklist (select as many as applicable)

- [x] The code follows the style guidelines of this project.
- [x] All new and existing tests pass.
- [x] This pull request is ready to be merged and reviewed.
