### PR TITLE
feat: add get_markets_by_creator function to retrieve markets by crea…

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+starknet-foundry 0.44.0
+scarb 2.11.4

--- a/contracts/src/interface.cairo
+++ b/contracts/src/interface.cairo
@@ -92,6 +92,9 @@ pub trait IPredictionHub<TContractState> {
     /// Returns an array of market IDs that a user has participated in
     fn get_user_market_ids(self: @TContractState, user: ContractAddress) -> Array<u256>;
 
+    /// Returns an array of markets created by a specific creator
+    fn get_markets_by_creator(self: @TContractState, creator: ContractAddress) -> Array<PredictionMarket>;
+
     // ================ Betting Functions ================
 
     /// Returns the protocol token contract address

--- a/contracts/src/prediction.cairo
+++ b/contracts/src/prediction.cairo
@@ -91,6 +91,7 @@ pub mod PredictionHub {
             (u256, ContractAddress, u8), bool,
         >, // (market_id, user, choice) to a boolean
         user_predictions: Map<ContractAddress, Vec<u256>>, // user to a list of market ids
+        market_creators: Map<u256, ContractAddress>, // market_id to creator address
         claimed: Map<(u256, ContractAddress), bool>,
         market_analytics: Map<u256, Vec<BetActivity>>, // market to a list of BetActivity structs
         // user analytics
@@ -433,6 +434,9 @@ pub mod PredictionHub {
             self.all_predictions.entry(market_id).write(market.clone());
 
             self.market_stats.entry(market_id).write(market_stats);
+
+            // Store the creator of this market
+            self.market_creators.entry(market_id).write(get_caller_address());
 
             self
                 .emit(
@@ -977,6 +981,26 @@ pub mod PredictionHub {
             }
 
             market_ids
+        }
+
+        fn get_markets_by_creator(self: @ContractState, creator: ContractAddress) -> Array<PredictionMarket> {
+            let mut creator_markets = ArrayTrait::new();
+            let count = self.prediction_count.read();
+
+            for i in 0..=count {
+                let market_id = self.market_ids.entry(i).read();
+
+                if market_id != 0 {
+                    let stored_creator = self.market_creators.entry(market_id).read();
+                    
+                    if stored_creator == creator {
+                        let market = self.all_predictions.entry(market_id).read();
+                        creator_markets.append(market);
+                    }
+                }
+            }
+
+            creator_markets
         }
 
 

--- a/contracts/tests/test_betting.cairo
+++ b/contracts/tests/test_betting.cairo
@@ -875,3 +875,4 @@ fn test_get_user_markets_by_status_all_statuses() {
     assert(resolved_markets.len() == 0, 'Resolved market'); // No resolved markets initially
     assert(closed_markets.len() == 0, 'Closed market'); // No closed markets initially
 }
+


### PR DESCRIPTION
# Add `get_markets_by_creator` function

## Summary

Implements a new view function to retrieve all markets created by a specific address, enabling better market discovery and creator analytics.

## 🔧 Changes

- **New storage mapping**: `market_creators: Map<u256, ContractAddress>` to track market creators
- **Updated market creation**: Store creator address when markets are created
- **New function**: `get_markets_by_creator(creator: ContractAddress) -> Array<PredictionMarket>`
- **Interface update**: Added function signature to the contract interface

## Implementation Details

- Function iterates through all markets and filters by creator address
- Returns empty array if no markets found for the creator
- Maintains consistency with existing market retrieval patterns
- No gas optimization needed as this is a view function

## ✅ Testing

- ✅ Contract compiles successfully
- ✅ Existing tests pass
- ✅ Function signature matches interface requirements

## Benefits

- Enables frontend to display creator-specific market lists
- Supports creator analytics and portfolio views
- Improves market discovery by creator
- Maintains backward compatibility

## Files Changed

- `contracts/src/prediction.cairo` - Implementation and storage
- `contracts/src/interface.cairo` - Interface definition

**Closes** #299 

